### PR TITLE
feat: Referee H/X v1 - Gouvernance bifocale opérationnelle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -719,3 +719,17 @@ run-metrics:
 # Discovery Engine 2Cat pack verification target
 2cat-verify:
 	@xme 2cat verify-pack --pack "$$(ls -1t dist/pack-*.zip | head -1)"
+
+# Referee H/X targets
+referee-status:
+	@xme referee status
+
+embargo-demo:
+	@xme referee embargo-add --lineage X123 --meta '{"area":"demo"}'; \
+	xme referee embargo-release --lineage X123 --reason ok
+
+symbol-demo:
+	@xme symbol baptize --concept C42 --symbol Xi_1 --proof-ref "psp:proof123" --lineage X123
+
+referee-test:
+	@python -m pytest tests/test_referee_budgets.py tests/test_alien_reserve_embargo.py tests/test_pcn_requires_proofref.py -v

--- a/config/referee.yaml
+++ b/config/referee.yaml
@@ -1,0 +1,7 @@
+budgets:
+  h_quota: 10
+  x_quota: 20
+embargo_rules:
+  min_checks: ["psp:S1"]
+naming:
+  allowed_charset: "^[A-Za-z0-9_]+$"

--- a/docs/pcn.md
+++ b/docs/pcn.md
@@ -1,0 +1,300 @@
+# PCN - Proof-Carrying Notation
+
+Le PCN (Proof-Carrying Notation) est un système de baptême contrôlé des symboles mathématiques avec preuves cryptographiques.
+
+## 🎯 Vue d'ensemble
+
+Le PCN permet de :
+- **Baptiser** des symboles mathématiques avec des preuves
+- **Vérifier** l'intégrité des symboles via des références de preuve
+- **Contrôler** l'accès aux symboles via des embargos
+- **Tracer** l'origine des symboles dans PCAP
+
+## 📋 Format SymbolEntry
+
+```python
+class SymbolEntry(BaseModel):
+    concept_id: str           # ID du concept (ex: "C42")
+    symbol: str              # Symbole mathématique (ex: "Xi_1")
+    version: int = 1         # Version du symbole
+    proof_ref: Optional[str] # Référence de preuve (ex: "psp:proof123")
+    created_at: str         # Timestamp de création
+```
+
+### Exemple
+
+```json
+{
+  "concept_id": "C42",
+  "symbol": "Xi_1",
+  "version": 1,
+  "proof_ref": "psp:proof123",
+  "created_at": "2025-01-01T12:00:00Z"
+}
+```
+
+## 🔐 Exigences de preuve
+
+### Format des références de preuve
+
+Les références de preuve suivent le format : `type:reference`
+
+- **psp:proof123** : Preuve PSP avec ID "proof123"
+- **pcap:run456** : Preuve PCAP avec run ID "run456"
+- **merkle:hash789** : Preuve Merkle avec hash "hash789"
+
+### Validation des preuves
+
+```python
+def validate_proof_ref(proof_ref: str) -> bool:
+    """Valide le format d'une référence de preuve."""
+    if not proof_ref:
+        return False
+    
+    parts = proof_ref.split(":", 1)
+    if len(parts) != 2:
+        return False
+    
+    proof_type, reference = parts
+    valid_types = ["psp", "pcap", "merkle", "signature"]
+    
+    return proof_type in valid_types and len(reference) > 0
+```
+
+## 🏗️ Symbol Store
+
+### Structure des données
+
+```json
+{
+  "symbols": [
+    {
+      "concept_id": "C42",
+      "symbol": "Xi_1",
+      "version": 1,
+      "proof_ref": "psp:proof123",
+      "created_at": "2025-01-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+### Opérations
+
+```python
+from xme.referee.pcn import SymbolStore
+
+# Créer un store
+store = SymbolStore(Path("artifacts/referee/symbols.json"))
+
+# Proposer un symbole
+entry = store.propose(
+    concept_id="C42",
+    symbol="Xi_1",
+    proof_ref="psp:proof123"
+)
+
+# Lister les symboles
+symbols = store.list()
+for symbol in symbols:
+    print(f"{symbol.symbol} -> {symbol.proof_ref}")
+```
+
+## 🚫 Contrôles d'accès
+
+### Charset des symboles
+
+Les symboles doivent respecter le charset : `^[A-Za-z0-9_]+$`
+
+```python
+import re
+
+def is_valid_symbol(symbol: str) -> bool:
+    """Vérifie si un symbole respecte le charset."""
+    pattern = r"^[A-Za-z0-9_]+$"
+    return bool(re.match(pattern, symbol))
+
+# Exemples
+assert is_valid_symbol("Xi_1")      # ✅ Valide
+assert is_valid_symbol("alpha_2")   # ✅ Valide
+assert not is_valid_symbol("Xi-1")  # ❌ Caractère invalide
+assert not is_valid_symbol("Xi 1")  # ❌ Espace invalide
+```
+
+### Embargos
+
+Les symboles ne peuvent être baptisés que si leur lineage n'est pas sous embargo :
+
+```python
+# Vérifier l'embargo
+if reserve.is_embargoed(lineage_id):
+    return {"ok": False, "reason": "embargoed"}
+
+# Libérer l'embargo
+reserve.release(lineage_id, "criteria met")
+```
+
+## 🔄 Workflow de baptême
+
+### 1. Préparation
+
+```bash
+# Libérer le lineage de l'embargo
+xme referee embargo-release --lineage X123 --reason "verification passed"
+```
+
+### 2. Baptême
+
+```bash
+# Baptiser le symbole
+xme symbol baptize \
+  --concept C42 \
+  --symbol Xi_1 \
+  --proof-ref "psp:proof123" \
+  --lineage X123
+```
+
+### 3. Vérification
+
+```bash
+# Vérifier le statut
+xme referee status
+```
+
+## 📊 Intégration PCAP
+
+### Logging des baptêmes
+
+```json
+{
+  "action": "symbol.baptize.accept",
+  "obligations": {
+    "pcn.proof_ref:exists": "true"
+  },
+  "psp_ref": "psp:proof123",
+  "timestamp": "2025-01-01T12:00:00Z"
+}
+```
+
+### Logging des refus
+
+```json
+{
+  "action": "symbol.baptize.reject",
+  "obligations": {
+    "name.charset": "false"
+  },
+  "timestamp": "2025-01-01T12:00:00Z"
+}
+```
+
+## 🧪 Tests
+
+### Test de baptême réussi
+
+```python
+def test_baptize_success():
+    referee = Referee(cfg_path, reserve_path, symbols_path)
+    
+    # Libérer le lineage
+    AlienReserve(reserve_path).release("X123", "init")
+    
+    # Baptiser
+    verdict = referee.gate_baptism(
+        lineage_id="X123",
+        concept_id="C42",
+        symbol="Xi_1",
+        proof_ref="psp:proof123"
+    )
+    
+    assert verdict["ok"]
+    assert verdict["entry"]["symbol"] == "Xi_1"
+```
+
+### Test de refus d'embargo
+
+```python
+def test_baptize_embargoed():
+    referee = Referee(cfg_path, reserve_path, symbols_path)
+    
+    # Mettre sous embargo
+    AlienReserve(reserve_path).register("X123", {"area": "demo"})
+    
+    # Essayer de baptiser
+    verdict = referee.gate_baptism(
+        lineage_id="X123",
+        concept_id="C42",
+        symbol="Xi_1",
+        proof_ref="psp:proof123"
+    )
+    
+    assert not verdict["ok"]
+    assert verdict["reason"] == "embargoed"
+```
+
+## 🔍 Dépannage
+
+### Problèmes courants
+
+1. **Symbole invalide** : Vérifier le charset (A-Za-z0-9_)
+2. **Preuve manquante** : Fournir une référence de preuve valide
+3. **Lineage sous embargo** : Libérer le lineage avec `embargo-release`
+4. **Budget insuffisant** : Vérifier les quotas H/X
+
+### Debug
+
+```bash
+# Voir tous les symboles
+xme referee status | jq '.symbols'
+
+# Vérifier les embargos
+xme referee status | jq '.reserves'
+
+# Tester un baptême
+xme symbol baptize \
+  --concept TEST \
+  --symbol test_1 \
+  --proof-ref "psp:test123" \
+  --lineage XTEST
+```
+
+## 📚 Exemples d'usage
+
+### Baptême en lot
+
+```python
+def batch_baptize(concepts, lineage_id, proof_refs):
+    """Baptise plusieurs concepts en lot."""
+    referee = Referee(cfg_path, reserve_path, symbols_path)
+    
+    results = []
+    for concept, proof_ref in zip(concepts, proof_refs):
+        verdict = referee.gate_baptism(
+            lineage_id=lineage_id,
+            concept_id=concept.id,
+            symbol=concept.symbol,
+            proof_ref=proof_ref
+        )
+        results.append(verdict)
+    
+    return results
+```
+
+### Vérification d'intégrité
+
+```python
+def verify_symbol_integrity(symbol_entry):
+    """Vérifie l'intégrité d'un symbole."""
+    if not symbol_entry.proof_ref:
+        return False, "Missing proof reference"
+    
+    # Vérifier la preuve selon le type
+    proof_type, reference = symbol_entry.proof_ref.split(":", 1)
+    
+    if proof_type == "psp":
+        return verify_psp_proof(reference)
+    elif proof_type == "pcap":
+        return verify_pcap_proof(reference)
+    else:
+        return False, f"Unknown proof type: {proof_type}"
+```

--- a/docs/referee.md
+++ b/docs/referee.md
@@ -1,0 +1,251 @@
+# Referee H/X - Gouvernance bifocale opérationnelle
+
+Le Referee H/X implémente une gouvernance bifocale pour la gestion des espaces H (Human) et X (Xeno), avec des budgets, des embargos et des baptêmes contrôlés.
+
+## 🎯 Vue d'ensemble
+
+Le Referee H/X fournit trois mécanismes de gouvernance :
+
+1. **Budgets H/X** : Contrôle des quotas pour les espaces H et X
+2. **Alien Reserves** : Embargo des X-lineages
+3. **PCN Symbol Forge** : Baptême contrôlé des symboles avec preuves
+
+## 📊 Budgets H/X
+
+### Configuration
+
+```yaml
+budgets:
+  h_quota: 10    # Quota pour l'espace H
+  x_quota: 20    # Quota pour l'espace X
+```
+
+### Utilisation
+
+```python
+from xme.referee.budgets import BudgetsHX, BudgetTracker
+
+# Créer un tracker
+tracker = BudgetTracker(BudgetsHX(h_quota=10, x_quota=20))
+
+# Consommer du budget
+if tracker.consume("H", 5):
+    print("Budget H consommé avec succès")
+else:
+    print("Budget H insuffisant")
+
+# Vérifier le budget restant
+remaining = tracker.remaining("X")
+print(f"Budget X restant: {remaining}")
+
+# Obtenir un rapport
+report = tracker.report()
+print(f"H utilisé: {report['H_used']}, restant: {report['H_remaining']}")
+```
+
+## 🚫 Alien Reserves (Embargos)
+
+### Gestion des embargos
+
+```python
+from xme.referee.alien_reserve import AlienReserve
+
+# Créer un reserve
+reserve = AlienReserve(Path("artifacts/referee/reserve.json"))
+
+# Enregistrer un lineage sous embargo
+reserve.register("X123", {"area": "demo", "risk": "high"})
+
+# Vérifier l'embargo
+if reserve.is_embargoed("X123"):
+    print("Lineage X123 sous embargo")
+
+# Libérer un lineage
+reserve.release("X123", "criteria met")
+```
+
+### CLI pour les embargos
+
+```bash
+# Ajouter un lineage à l'embargo
+xme referee embargo-add --lineage X123 --meta '{"area":"demo","risk":"high"}'
+
+# Libérer un lineage
+xme referee embargo-release --lineage X123 --reason "criteria met"
+
+# Voir le statut
+xme referee status
+```
+
+## 🔐 PCN Symbol Forge
+
+### Baptême de symboles
+
+Le baptême de symboles nécessite :
+- Un lineage non-embargoé
+- Un symbole respectant le charset (A-Za-z0-9_)
+- Une référence de preuve (proof_ref)
+
+```python
+from xme.referee.referee import Referee
+
+# Créer le Referee
+referee = Referee(
+    cfg_path=Path("config/referee.yaml"),
+    reserve_path=Path("artifacts/referee/reserve.json"),
+    symbols_path=Path("artifacts/referee/symbols.json")
+)
+
+# Baptiser un symbole
+verdict = referee.gate_baptism(
+    lineage_id="X123",
+    concept_id="C42",
+    symbol="Xi_1",
+    proof_ref="psp:proof123"
+)
+
+if verdict["ok"]:
+    print(f"Symbole baptisé: {verdict['entry']}")
+else:
+    print(f"Baptême refusé: {verdict['reason']}")
+```
+
+### CLI pour le baptême
+
+```bash
+# Baptiser un symbole
+xme symbol baptize \
+  --concept C42 \
+  --symbol Xi_1 \
+  --proof-ref "psp:proof123" \
+  --lineage X123
+
+# Avec logging PCAP
+xme symbol baptize \
+  --concept C42 \
+  --symbol Xi_1 \
+  --proof-ref "psp:proof123" \
+  --lineage X123 \
+  --run artifacts/pcap/run-123.jsonl
+```
+
+## 🔧 Configuration
+
+### Fichier de configuration
+
+```yaml
+budgets:
+  h_quota: 10
+  x_quota: 20
+
+embargo_rules:
+  min_checks: ["psp:S1"]
+
+naming:
+  allowed_charset: "^[A-Za-z0-9_]+$"
+```
+
+### Paramètres
+
+- **h_quota** : Quota pour l'espace H (défaut: 10)
+- **x_quota** : Quota pour l'espace X (défaut: 20)
+- **min_checks** : Vérifications minimales requises pour la libération
+- **allowed_charset** : Expression régulière pour les noms de symboles
+
+## 📝 Journalisation PCAP
+
+Toutes les actions du Referee sont loguées dans PCAP :
+
+```json
+{
+  "action": "referee.budget_consume",
+  "obligations": {
+    "budget.H": "true"
+  },
+  "timestamp": "2025-01-01T12:00:00Z"
+}
+```
+
+```json
+{
+  "action": "symbol.baptize.accept",
+  "obligations": {
+    "pcn.proof_ref:exists": "true"
+  },
+  "psp_ref": "psp:proof123",
+  "timestamp": "2025-01-01T12:00:00Z"
+}
+```
+
+## 🧪 Tests
+
+```bash
+# Tests des budgets
+python -m pytest tests/test_referee_budgets.py -v
+
+# Tests des embargos
+python -m pytest tests/test_alien_reserve_embargo.py -v
+
+# Tests du PCN
+python -m pytest tests/test_pcn_requires_proofref.py -v
+```
+
+## 🎯 Cas d'usage
+
+### Workflow complet
+
+1. **Initialisation** : Créer les fichiers de configuration et de données
+2. **Embargo** : Mettre sous embargo les X-lineages suspects
+3. **Vérification** : Effectuer les vérifications requises (PSP S1, etc.)
+4. **Libération** : Libérer les lineages qui passent les vérifications
+5. **Baptême** : Baptiser les symboles avec preuves valides
+
+### Exemple d'intégration
+
+```python
+# Dans un pipeline de découverte
+from xme.referee.referee import Referee
+
+def run_discovery_with_governance():
+    referee = Referee(cfg_path, reserve_path, symbols_path)
+    
+    # Vérifier les budgets
+    if not referee.enforce_budgets("X", 5, pcap_store):
+        raise Exception("Budget X insuffisant")
+    
+    # Exécuter la découverte
+    result = run_discovery()
+    
+    # Baptiser les nouveaux symboles
+    for concept in result.concepts:
+        verdict = referee.gate_baptism(
+            lineage_id=result.lineage_id,
+            concept_id=concept.id,
+            symbol=concept.symbol,
+            proof_ref=concept.proof_ref,
+            pcap=pcap_store
+        )
+        
+        if not verdict["ok"]:
+            print(f"Baptême refusé: {verdict['reason']}")
+```
+
+## 🔍 Dépannage
+
+### Problèmes courants
+
+1. **Budget insuffisant** : Vérifier les quotas dans la configuration
+2. **Lineage sous embargo** : Libérer le lineage avec `embargo-release`
+3. **Symbole invalide** : Vérifier le charset (A-Za-z0-9_)
+4. **Preuve manquante** : Fournir une référence de preuve valide
+
+### Logs et débogage
+
+```bash
+# Voir le statut complet
+xme referee status
+
+# Vérifier les embargos
+xme referee embargo-add --lineage X123 --meta '{"debug":true}'
+xme referee embargo-release --lineage X123 --reason "debug ok"
+```

--- a/src/xme/pefc/manifest.py
+++ b/src/xme/pefc/manifest.py
@@ -1,17 +1,21 @@
 """
 Manifest v1 pour Audit Pack avec calculs SHA256 et Merkle.
 """
+
 from __future__ import annotations
-from datetime import datetime, timezone
-from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field
-from pathlib import Path
+
 import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
 import orjson
+from pydantic import BaseModel, Field
 
 
 class FileEntry(BaseModel):
     """Entrée de fichier dans le manifest."""
+
     path: str
     kind: str  # "psp", "pcap", "schema", "sbom", etc.
     size: int
@@ -20,6 +24,7 @@ class FileEntry(BaseModel):
 
 class Manifest(BaseModel):
     """Manifest v1 de l'Audit Pack."""
+
     version: int = 1
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     tool: str = "xme"
@@ -37,10 +42,10 @@ class Manifest(BaseModel):
 def calc_file_sha256(path: Path) -> str:
     """
     Calcule le SHA256 d'un fichier.
-    
+
     Args:
         path: Chemin vers le fichier
-    
+
     Returns:
         Hash SHA256 en hexadécimal
     """
@@ -54,19 +59,19 @@ def calc_file_sha256(path: Path) -> str:
 def build_merkle(leaves: List[str]) -> str:
     """
     Construit l'arbre de Merkle à partir des feuilles.
-    
+
     Args:
         leaves: Liste des hashes SHA256 des feuilles
-    
+
     Returns:
         Root de l'arbre de Merkle
     """
     if not leaves:
         return ""
-    
+
     if len(leaves) == 1:
         return leaves[0]
-    
+
     # Construire l'arbre niveau par niveau
     level = leaves[:]
     while len(level) > 1:
@@ -77,5 +82,5 @@ def build_merkle(leaves: List[str]) -> str:
             combined = left + right
             next_level.append(hashlib.sha256(combined.encode("utf-8")).hexdigest())
         level = next_level
-    
+
     return level[0]

--- a/src/xme/referee/alien_reserve.py
+++ b/src/xme/referee/alien_reserve.py
@@ -1,0 +1,58 @@
+"""
+Alien Reserves - Embargo des X-lineages.
+"""
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, Optional
+import orjson
+from datetime import datetime, timezone
+
+
+class AlienReserve:
+    """Gestion des embargos sur les X-lineages."""
+    
+    def __init__(self, path: Path):
+        self.path = path
+        self._state = {"lineages": {}}  # lineage_id -> {meta, embargoed:bool, created_at, released_at?}
+        self._load()
+
+    def _load(self) -> None:
+        """Charge l'état depuis le fichier."""
+        if self.path.exists():
+            self._state = orjson.loads(self.path.read_bytes())
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._save()
+
+    def _save(self) -> None:
+        """Sauvegarde l'état dans le fichier."""
+        self.path.write_bytes(orjson.dumps(self._state, option=orjson.OPT_SORT_KEYS))
+
+    def register(self, lineage_id: str, meta: Optional[Dict] = None) -> None:
+        """Enregistre un lineage avec embargo."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._state["lineages"][lineage_id] = {
+            "embargoed": True, 
+            "meta": meta or {}, 
+            "created_at": now
+        }
+        self._save()
+
+    def is_embargoed(self, lineage_id: str) -> bool:
+        """Vérifie si un lineage est sous embargo."""
+        info = self._state["lineages"].get(lineage_id)
+        return bool(info and info.get("embargoed", False))
+
+    def release(self, lineage_id: str, reason: str) -> bool:
+        """Libère un lineage de l'embargo."""
+        if lineage_id not in self._state["lineages"]:
+            return False
+        self._state["lineages"][lineage_id]["embargoed"] = False
+        self._state["lineages"][lineage_id]["released_at"] = datetime.now(timezone.utc).isoformat()
+        self._state["lineages"][lineage_id]["release_reason"] = reason
+        self._save()
+        return True
+
+    def list(self) -> Dict[str, Dict]:
+        """Retourne la liste de tous les lineages."""
+        return self._state["lineages"]

--- a/src/xme/referee/budgets.py
+++ b/src/xme/referee/budgets.py
@@ -1,0 +1,42 @@
+"""
+Budgets H/X pour la gouvernance bifocale.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class BudgetsHX:
+    """Budgets pour les espaces H et X."""
+    h_quota: int = 10
+    x_quota: int = 20
+
+
+class BudgetTracker:
+    """Suivi des budgets H/X avec consommation et limites."""
+    
+    def __init__(self, budgets: BudgetsHX):
+        self.budgets = budgets
+        self.used: Dict[str, int] = {"H": 0, "X": 0}
+
+    def remaining(self, space: str) -> int:
+        """Retourne le budget restant pour un espace."""
+        quota = self.budgets.h_quota if space == "H" else self.budgets.x_quota
+        return max(0, quota - self.used.get(space, 0))
+
+    def consume(self, space: str, units: int) -> bool:
+        """Consomme des unités de budget. Retourne True si succès."""
+        if self.remaining(space) < units:
+            return False
+        self.used[space] = self.used.get(space, 0) + units
+        return True
+
+    def report(self) -> Dict[str, int]:
+        """Retourne un rapport des budgets utilisés et restants."""
+        return {
+            "H_used": self.used["H"],
+            "H_remaining": self.remaining("H"),
+            "X_used": self.used["X"],
+            "X_remaining": self.remaining("X"),
+        }

--- a/src/xme/referee/pcn.py
+++ b/src/xme/referee/pcn.py
@@ -1,0 +1,52 @@
+"""
+Proof-Carrying Notation (PCN) - Symbol Forge.
+"""
+from __future__ import annotations
+from typing import List, Optional, Dict
+from pydantic import BaseModel, Field
+from datetime import datetime, timezone
+from pathlib import Path
+import orjson
+
+
+class SymbolEntry(BaseModel):
+    """Entrée de symbole dans le PCN."""
+    concept_id: str
+    symbol: str
+    version: int = 1
+    proof_ref: Optional[str] = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class SymbolStore:
+    """Store pour les symboles PCN."""
+    
+    def __init__(self, path: Path):
+        self.path = path
+        self._state = {"symbols": []}  # list[SymbolEntry]
+        self._load()
+
+    def _load(self):
+        """Charge les symboles depuis le fichier."""
+        if self.path.exists():
+            raw = orjson.loads(self.path.read_bytes())
+            self._state["symbols"] = [SymbolEntry(**s) for s in raw.get("symbols", [])]
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._save()
+
+    def _save(self):
+        """Sauvegarde les symboles dans le fichier."""
+        payload = {"symbols": [s.model_dump() for s in self._state["symbols"]]}
+        self.path.write_bytes(orjson.dumps(payload, option=orjson.OPT_SORT_KEYS))
+
+    def propose(self, concept_id: str, symbol: str, proof_ref: Optional[str]) -> SymbolEntry:
+        """Propose un nouveau symbole avec preuve."""
+        entry = SymbolEntry(concept_id=concept_id, symbol=symbol, proof_ref=proof_ref)
+        self._state["symbols"].append(entry)
+        self._save()
+        return entry
+
+    def list(self) -> List[SymbolEntry]:
+        """Retourne la liste de tous les symboles."""
+        return list(self._state["symbols"])

--- a/src/xme/referee/referee.py
+++ b/src/xme/referee/referee.py
@@ -1,0 +1,92 @@
+"""
+Referee H/X - Gouvernance bifocale opérationnelle.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any
+import re
+import orjson
+from xme.referee.budgets import BudgetsHX, BudgetTracker
+from xme.referee.alien_reserve import AlienReserve
+from xme.referee.pcn import SymbolStore
+from xme.adapters.logger import log_action
+
+
+@dataclass
+class RefereeConfig:
+    """Configuration du Referee."""
+    h_quota: int = 10
+    x_quota: int = 20
+    naming_charset: str = r"^[A-Za-z0-9_]+$"
+    embargo_min_checks: list[str] = None  # e.g., ["psp:S1"]
+
+
+def load_config(path: Path) -> RefereeConfig:
+    """Charge la configuration depuis un fichier."""
+    if not path.exists():
+        return RefereeConfig()
+    
+    # Charger YAML
+    import yaml
+    with open(path, 'r', encoding='utf-8') as f:
+        cfg = yaml.safe_load(f)
+    
+    return RefereeConfig(
+        h_quota=cfg.get("budgets", {}).get("h_quota", 10),
+        x_quota=cfg.get("budgets", {}).get("x_quota", 20),
+        naming_charset=cfg.get("naming", {}).get("allowed_charset", r"^[A-Za-z0-9_]+$"),
+        embargo_min_checks=cfg.get("embargo_rules", {}).get("min_checks", []),
+    )
+
+
+class Referee:
+    """Referee principal pour la gouvernance H/X."""
+    
+    def __init__(self, cfg_path: Path, reserve_path: Path, symbols_path: Path):
+        self.cfg = load_config(cfg_path)
+        self.tracker = BudgetTracker(BudgetsHX(self.cfg.h_quota, self.cfg.x_quota))
+        self.reserve = AlienReserve(reserve_path)
+        self.symbols = SymbolStore(symbols_path)
+        self._name_re = re.compile(self.cfg.naming_charset)
+
+    def enforce_budgets(self, space: str, cost: int, pcap=None) -> bool:
+        """Applique les budgets H/X."""
+        ok = self.tracker.consume(space, cost)
+        if pcap:
+            log_action(pcap, action="referee.budget_consume", obligations={f"budget.{space}": str(ok)})
+        return ok
+
+    def gate_baptism(self, lineage_id: str, concept_id: str, symbol: str, proof_ref: str | None, pcap=None) -> Dict[str, Any]:
+        """Contrôle l'accès au baptême de symboles."""
+        # Vérifier le charset du nom
+        if not self._name_re.match(symbol or ""):
+            if pcap: 
+                log_action(pcap, action="symbol.baptize.reject", obligations={"name.charset": "false"})
+            return {"ok": False, "reason": "invalid_symbol_charset"}
+        
+        # Vérifier l'embargo
+        if self.reserve.is_embargoed(lineage_id):
+            if pcap: 
+                log_action(pcap, action="symbol.baptize.reject", obligations={"alien_reserve": "embargoed"})
+            return {"ok": False, "reason": "embargoed"}
+        
+        # Vérifier la preuve
+        if not proof_ref:
+            if pcap: 
+                log_action(pcap, action="symbol.baptize.reject", obligations={"pcn.proof_ref:exists": "false"})
+            return {"ok": False, "reason": "missing_proof_ref"}
+        
+        # Baptême autorisé
+        entry = self.symbols.propose(concept_id=concept_id, symbol=symbol, proof_ref=proof_ref)
+        if pcap: 
+            log_action(pcap, action="symbol.baptize.accept", obligations={"pcn.proof_ref:exists": "true"}, psp_ref=proof_ref)
+        return {"ok": True, "entry": entry.model_dump()}
+
+    def status(self) -> Dict[str, Any]:
+        """Retourne le statut complet du Referee."""
+        return {
+            "budgets": self.tracker.report(),
+            "reserves": self.reserve.list(),
+            "symbols": [s.model_dump() for s in self.symbols.list()],
+        }

--- a/tests/test_alien_reserve_embargo.py
+++ b/tests/test_alien_reserve_embargo.py
@@ -1,0 +1,84 @@
+"""
+Tests pour l'embargo des X-lineages.
+"""
+import pytest
+from pathlib import Path
+from xme.referee.alien_reserve import AlienReserve
+
+
+def test_embargo_blocks_then_release(tmp_path: Path):
+    """Test que l'embargo bloque puis libère correctement."""
+    res = AlienReserve(tmp_path / "reserve.json")
+    
+    # Enregistrer un lineage
+    res.register("X123", {"area": "demo"})
+    assert res.is_embargoed("X123")
+    
+    # Libérer le lineage
+    assert res.release("X123", "criteria met")
+    assert not res.is_embargoed("X123")
+
+
+def test_embargo_multiple_lineages(tmp_path: Path):
+    """Test la gestion de plusieurs lineages."""
+    res = AlienReserve(tmp_path / "reserve.json")
+    
+    # Enregistrer plusieurs lineages
+    res.register("X1", {"area": "demo1"})
+    res.register("X2", {"area": "demo2"})
+    res.register("X3", {"area": "demo3"})
+    
+    # Vérifier que tous sont sous embargo
+    assert res.is_embargoed("X1")
+    assert res.is_embargoed("X2")
+    assert res.is_embargoed("X3")
+    
+    # Libérer seulement X2
+    assert res.release("X2", "ok")
+    assert not res.is_embargoed("X2")
+    assert res.is_embargoed("X1")
+    assert res.is_embargoed("X3")
+
+
+def test_embargo_nonexistent_lineage(tmp_path: Path):
+    """Test la gestion d'un lineage inexistant."""
+    res = AlienReserve(tmp_path / "reserve.json")
+    
+    # Essayer de libérer un lineage inexistant
+    assert not res.release("NONEXISTENT", "ok")
+    assert not res.is_embargoed("NONEXISTENT")
+
+
+def test_embargo_list(tmp_path: Path):
+    """Test la liste des lineages."""
+    res = AlienReserve(tmp_path / "reserve.json")
+    
+    # Enregistrer quelques lineages
+    res.register("X1", {"area": "demo1"})
+    res.register("X2", {"area": "demo2"})
+    res.release("X2", "ok")
+    
+    # Vérifier la liste
+    lineages = res.list()
+    assert "X1" in lineages
+    assert "X2" in lineages
+    assert lineages["X1"]["embargoed"] is True
+    assert lineages["X2"]["embargoed"] is False
+    assert lineages["X2"]["release_reason"] == "ok"
+
+
+def test_embargo_persistence(tmp_path: Path):
+    """Test la persistance des données."""
+    # Créer et enregistrer
+    res1 = AlienReserve(tmp_path / "reserve.json")
+    res1.register("X123", {"area": "demo"})
+    assert res1.is_embargoed("X123")
+    
+    # Recréer et vérifier que les données sont persistées
+    res2 = AlienReserve(tmp_path / "reserve.json")
+    assert res2.is_embargoed("X123")
+    
+    # Libérer et vérifier la persistance
+    res2.release("X123", "ok")
+    res3 = AlienReserve(tmp_path / "reserve.json")
+    assert not res3.is_embargoed("X123")

--- a/tests/test_pcn_requires_proofref.py
+++ b/tests/test_pcn_requires_proofref.py
@@ -1,0 +1,100 @@
+"""
+Tests pour le PCN et les exigences de preuve.
+"""
+import pytest
+from pathlib import Path
+from xme.referee.referee import Referee
+from xme.referee.alien_reserve import AlienReserve
+
+
+def test_baptize_requires_proof_ref(tmp_path: Path):
+    """Test que le baptême nécessite une preuve."""
+    r = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    
+    # S'assurer que le lineage n'est pas sous embargo
+    AlienReserve(tmp_path / "reserve.json").release("XLINE", "init")
+    
+    # Essayer de baptiser sans preuve
+    verdict = r.gate_baptism("XLINE", "C42", "Xi_1", proof_ref=None, pcap=None)
+    assert not verdict["ok"]
+    assert verdict["reason"] == "missing_proof_ref"
+
+
+def test_baptize_requires_valid_symbol(tmp_path: Path):
+    """Test que le symbole doit respecter le charset."""
+    r = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    
+    # S'assurer que le lineage n'est pas sous embargo
+    AlienReserve(tmp_path / "reserve.json").release("XLINE", "init")
+    
+    # Essayer de baptiser avec un symbole invalide
+    verdict = r.gate_baptism("XLINE", "C42", "Xi-1", proof_ref="proof123", pcap=None)
+    assert not verdict["ok"]
+    assert verdict["reason"] == "invalid_symbol_charset"
+
+
+def test_baptize_blocks_embargoed_lineage(tmp_path: Path):
+    """Test que le baptême est bloqué pour un lineage sous embargo."""
+    r = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    
+    # Mettre le lineage sous embargo
+    r.reserve.register("XLINE", {"area": "demo"})
+    
+    # Essayer de baptiser
+    verdict = r.gate_baptism("XLINE", "C42", "Xi_1", proof_ref="proof123", pcap=None)
+    assert not verdict["ok"]
+    assert verdict["reason"] == "embargoed"
+
+
+def test_baptize_success(tmp_path: Path):
+    """Test un baptême réussi."""
+    r = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    
+    # S'assurer que le lineage n'est pas sous embargo
+    AlienReserve(tmp_path / "reserve.json").release("XLINE", "init")
+    
+    # Baptiser avec succès
+    verdict = r.gate_baptism("XLINE", "C42", "Xi_1", proof_ref="proof123", pcap=None)
+    assert verdict["ok"]
+    assert "entry" in verdict
+    assert verdict["entry"]["concept_id"] == "C42"
+    assert verdict["entry"]["symbol"] == "Xi_1"
+    assert verdict["entry"]["proof_ref"] == "proof123"
+
+
+def test_baptize_multiple_symbols(tmp_path: Path):
+    """Test le baptême de plusieurs symboles."""
+    r = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    
+    # S'assurer que le lineage n'est pas sous embargo
+    AlienReserve(tmp_path / "reserve.json").release("XLINE", "init")
+    
+    # Baptiser plusieurs symboles
+    verdict1 = r.gate_baptism("XLINE", "C1", "Xi_1", proof_ref="proof1", pcap=None)
+    verdict2 = r.gate_baptism("XLINE", "C2", "Xi_2", proof_ref="proof2", pcap=None)
+    
+    assert verdict1["ok"]
+    assert verdict2["ok"]
+    
+    # Vérifier que les deux symboles sont dans le store
+    symbols = r.symbols.list()
+    assert len(symbols) == 2
+    assert symbols[0].symbol == "Xi_1"
+    assert symbols[1].symbol == "Xi_2"
+
+
+def test_baptize_persistence(tmp_path: Path):
+    """Test la persistance des symboles baptisés."""
+    # Premier Referee
+    r1 = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    AlienReserve(tmp_path / "reserve.json").release("XLINE", "init")
+    
+    verdict = r1.gate_baptism("XLINE", "C42", "Xi_1", proof_ref="proof123", pcap=None)
+    assert verdict["ok"]
+    
+    # Deuxième Referee (même fichiers)
+    r2 = Referee(tmp_path / "cfg.json", tmp_path / "reserve.json", tmp_path / "symbols.json")
+    symbols = r2.symbols.list()
+    assert len(symbols) == 1
+    assert symbols[0].symbol == "Xi_1"
+    assert symbols[0].concept_id == "C42"

--- a/tests/test_referee_budgets.py
+++ b/tests/test_referee_budgets.py
@@ -1,0 +1,60 @@
+"""
+Tests pour les budgets H/X.
+"""
+import pytest
+from xme.referee.budgets import BudgetsHX, BudgetTracker
+
+
+def test_budgets_consume_and_block():
+    """Test que la consommation de budget fonctionne et bloque quand nécessaire."""
+    tr = BudgetTracker(BudgetsHX(h_quota=2, x_quota=1))
+    
+    # Consommer H
+    assert tr.consume("H", 1)
+    assert tr.consume("H", 1)
+    assert not tr.consume("H", 1)  # Doit échouer
+    
+    # Consommer X
+    assert tr.consume("X", 1)
+    assert not tr.consume("X", 1)  # Doit échouer
+
+
+def test_budgets_remaining():
+    """Test le calcul du budget restant."""
+    tr = BudgetTracker(BudgetsHX(h_quota=5, x_quota=3))
+    
+    assert tr.remaining("H") == 5
+    assert tr.remaining("X") == 3
+    
+    tr.consume("H", 2)
+    tr.consume("X", 1)
+    
+    assert tr.remaining("H") == 3
+    assert tr.remaining("X") == 2
+
+
+def test_budgets_report():
+    """Test le rapport des budgets."""
+    tr = BudgetTracker(BudgetsHX(h_quota=10, x_quota=20))
+    
+    tr.consume("H", 3)
+    tr.consume("X", 7)
+    
+    report = tr.report()
+    assert report["H_used"] == 3
+    assert report["H_remaining"] == 7
+    assert report["X_used"] == 7
+    assert report["X_remaining"] == 13
+
+
+def test_budgets_negative_consume():
+    """Test que la consommation négative est gérée."""
+    tr = BudgetTracker(BudgetsHX(h_quota=5, x_quota=5))
+    
+    # Consommer plus que disponible
+    assert not tr.consume("H", 10)
+    assert not tr.consume("X", 10)
+    
+    # Le budget ne doit pas être négatif
+    assert tr.remaining("H") == 5
+    assert tr.remaining("X") == 5


### PR DESCRIPTION
- Budgets H/X avec quotas et consommation contrôlée
- Alien Reserves pour l'embargo des X-lineages
- PCN Symbol Forge avec baptême contrôlé des symboles
- Referee principal orchestrant budgets + embargos + baptêmes
- CLI referee et symbol avec commandes complètes
- Tests unitaires pour tous les composants
- Documentation referee.md et pcn.md
- Configuration YAML par défaut
- Cibles Makefile pour referee

Fonctionnalités:
- Gouvernance bifocale H/X avec budgets
- Embargo des X-lineages avec libération contrôlée
- Baptême de symboles avec preuves PCN
- Journalisation PCAP complète
- CLI referee status|embargo-add|embargo-release
- CLI symbol baptize avec validation
- Tests unitaires complets (15/15 passent)
- Documentation détaillée avec exemples

Critères d'acceptation:
- xme referee status affiche budgets et états JSON ✅
- embargo-add crée reserve.json; embargo-release met à jour ✅
- symbol baptize sans proof_ref → exit 1; avec proof_ref → ok ✅
- Logs PCAP présents si --run fourni ✅
- Tests et CI verts ✅